### PR TITLE
Add rating property to Movie and MovieDTO

### DIFF
--- a/src/MyApp/Features/Movies/Index.razor
+++ b/src/MyApp/Features/Movies/Index.razor
@@ -21,6 +21,7 @@ else
                 <th>Title</th>
                 <th>Director</th>
                 <th>Year</th>
+                <th>Rating</th>
             </tr>
         </thead>
         <tbody>
@@ -30,6 +31,7 @@ else
                     <td>@movie.Title</td>
                     <td>@movie.Director</td>
                     <td>@movie.Year</td>
+                    <td>@movie.Rating</td>
                 </tr>
             }
         </tbody>

--- a/src/MyApp/Features/Movies/MovieDTO.cs
+++ b/src/MyApp/Features/Movies/MovieDTO.cs
@@ -1,3 +1,3 @@
 namespace MyApp.Features.Movies;
 
-public record MovieDTO(int Id, string Title, string? Director, int Year);
+public record MovieDTO(int Id, string Title, string? Director, int Year, double Rating);

--- a/src/MyApp/Features/Movies/MovieService.cs
+++ b/src/MyApp/Features/Movies/MovieService.cs
@@ -10,6 +10,6 @@ public class MovieService(AppDbContext context) : IMovieService
     public async Task<IEnumerable<MovieDTO>> ReadAll() =>
         await _context.Movies
             .OrderBy(m => m.Title)
-            .Select(static m => new MovieDTO(m.Id, m.Title, m.Director != null ? m.Director.Name : null, m.Year))
+            .Select(static m => new MovieDTO(m.Id, m.Title, m.Director != null ? m.Director.Name : null, m.Year, m.Rating))
             .ToArrayAsync();
 }

--- a/src/MyApp/Features/Shared/AppDbContext.cs
+++ b/src/MyApp/Features/Shared/AppDbContext.cs
@@ -34,16 +34,16 @@ public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(op
         );
 
         modelBuilder.Entity<Movie>().HasData(
-            new Movie { Id = 1, Title = "The Shawshank Redemption", DirectorId = 1, Year = 1994 },
-            new Movie { Id = 2, Title = "The Godfather", DirectorId = 2, Year = 1972 },
-            new Movie { Id = 3, Title = "The Dark Knight", DirectorId = 3, Year = 2008 },
-            new Movie { Id = 4, Title = "The Godfather Part II", DirectorId = 1, Year = 1974 },
-            new Movie { Id = 5, Title = "12 Angry Men", DirectorId = 4, Year = 1957 },
-            new Movie { Id = 6, Title = "Schindler's List", DirectorId = 5, Year = 1993 },
-            new Movie { Id = 7, Title = "The Lord of the Rings: The Return of the King", DirectorId = 6, Year = 2003 },
-            new Movie { Id = 8, Title = "Pulp Fiction", DirectorId = 7, Year = 1994 },
-            new Movie { Id = 9, Title = "The Lord of the Rings: The Fellowship of the Ring", DirectorId = 6, Year = 2001 },
-            new Movie { Id = 10, Title = "The Good, the Bad and the Ugly", DirectorId = 8, Year = 1966 }
+            new Movie { Id = 1, Title = "The Shawshank Redemption", DirectorId = 1, Year = 1994, Rating = 9.3 },
+            new Movie { Id = 2, Title = "The Godfather", DirectorId = 2, Year = 1972, Rating = 9.2 },
+            new Movie { Id = 3, Title = "The Dark Knight", DirectorId = 3, Year = 2008, Rating = 9.0 },
+            new Movie { Id = 4, Title = "The Godfather Part II", DirectorId = 1, Year = 1974, Rating = 9.0 },
+            new Movie { Id = 5, Title = "12 Angry Men", DirectorId = 4, Year = 1957, Rating = 9.0 },
+            new Movie { Id = 6, Title = "Schindler's List", DirectorId = 5, Year = 1993, Rating = 8.9 },
+            new Movie { Id = 7, Title = "The Lord of the Rings: The Return of the King", DirectorId = 6, Year = 2003, Rating = 8.9 },
+            new Movie { Id = 8, Title = "Pulp Fiction", DirectorId = 7, Year = 1994, Rating = 8.9 },
+            new Movie { Id = 9, Title = "The Lord of the Rings: The Fellowship of the Ring", DirectorId = 6, Year = 2001, Rating = 8.8 },
+            new Movie { Id = 10, Title = "The Good, the Bad and the Ugly", DirectorId = 8, Year = 1966, Rating = 8.8 }
         );
     }
 }

--- a/src/MyApp/Features/Shared/Movie.cs
+++ b/src/MyApp/Features/Shared/Movie.cs
@@ -7,4 +7,5 @@ public class Movie
     public int? DirectorId { get; set; }
     public Person? Director { get; set; }
     public int Year { get; set; }
+    public double Rating { get; set; }
 }

--- a/src/MyApp/Migrations/20240905111117_AddRatingToMovies.Designer.cs
+++ b/src/MyApp/Migrations/20240905111117_AddRatingToMovies.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyApp.Features.Shared;
 
@@ -10,9 +11,11 @@ using MyApp.Features.Shared;
 namespace MyApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240905111117_AddRatingToMovies")]
+    partial class AddRatingToMovies
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MyApp/Migrations/20240905111117_AddRatingToMovies.cs
+++ b/src/MyApp/Migrations/20240905111117_AddRatingToMovies.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRatingToMovies : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Rating",
+                table: "Movies",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Rating",
+                value: 9.3000000000000007);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Rating",
+                value: 9.1999999999999993);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Rating",
+                value: 9.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Rating",
+                value: 9.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Rating",
+                value: 9.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Rating",
+                value: 8.9000000000000004);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Rating",
+                value: 8.9000000000000004);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Rating",
+                value: 8.9000000000000004);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Rating",
+                value: 8.8000000000000007);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "Rating",
+                value: 8.8000000000000007);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Rating",
+                table: "Movies");
+        }
+    }
+}

--- a/tests/MyApp.Tests/Features/Movies/MovieServiceTests.cs
+++ b/tests/MyApp.Tests/Features/Movies/MovieServiceTests.cs
@@ -30,7 +30,7 @@ public sealed class MovieServiceTests : IAsyncLifetime
     {
         var movies = await _service.ReadAll();
 
-        var pulpFiction = new MovieDTO(8, "Pulp Fiction", "Quentin Tarantino", 1994);
+        var pulpFiction = new MovieDTO(8, "Pulp Fiction", "Quentin Tarantino", 1994, 8.9);
 
         movies.Should().Contain(pulpFiction);
     }


### PR DESCRIPTION
This pull request introduces a new `Rating` field to the `Movie` entity and updates the relevant parts of the application to accommodate this change. The most important changes include modifications to the data model, service layer, and UI components to display and handle the new `Rating` field.

### Data Model Changes:
* [`src/MyApp/Features/Movies/MovieDTO.cs`](diffhunk://#diff-f02917c130a892ae7e418a0e50316c476dd4cd76626826da3f7186dff63e83ccL3-R3): Added `Rating` field to the `MovieDTO` record.
* [`src/MyApp/Features/Shared/Movie.cs`](diffhunk://#diff-6d0fb19b792c8b0acf7afb8175d9586063ceeb678c1f3b0d8e4fec77b9491233R10): Added `Rating` property to the `Movie` class.
* [`src/MyApp/Features/Shared/AppDbContext.cs`](diffhunk://#diff-2e54266ebb4d872e972464a18a5607c9e3385a18c4a8cbb1893af8e55a51ea6cL37-R46): Updated seed data to include `Rating` values for movies.

### Service Layer Changes:
* [`src/MyApp/Features/Movies/MovieService.cs`](diffhunk://#diff-f796ff3e2485b7b6adc0482fc41a54bc0505067de7141fc95568538f63c01329L13-R13): Updated the `ReadAll` method to include the `Rating` field when mapping to `MovieDTO`.

### UI Changes:
* [`src/MyApp/Features/Movies/Index.razor`](diffhunk://#diff-676db8169c49d36c1ae99f711ffc3aa09aee07406aea8913b8e81f5deb1a8205R24): Added a new column for `Rating` in the movies table. [[1]](diffhunk://#diff-676db8169c49d36c1ae99f711ffc3aa09aee07406aea8913b8e81f5deb1a8205R24) [[2]](diffhunk://#diff-676db8169c49d36c1ae99f711ffc3aa09aee07406aea8913b8e81f5deb1a8205R34)

### Database Migration:
* [`src/MyApp/Migrations/20240905111117_AddRatingToMovies.cs`](diffhunk://#diff-84cc85f4b6fbe22fefcacf22d5d1eea719816fe069831569993a2958a0ebd71eR1-R99): Created a migration to add the `Rating` column to the `Movies` table and update existing records.
* [`src/MyApp/Migrations/20240905111117_AddRatingToMovies.Designer.cs`](diffhunk://#diff-fa2e10dbf9aee2cb1c9ffc15b0f0175a59f5079deef833ede203f1d2074db6f1R1-R214): Updated the model snapshot to include the `Rating` field. [[1]](diffhunk://#diff-fa2e10dbf9aee2cb1c9ffc15b0f0175a59f5079deef833ede203f1d2074db6f1R1-R214) [[2]](diffhunk://#diff-349d001931984d6c50353283db734dc95ef91e89f2df6bd9afe29a681d9d94a7R35-R37) [[3]](diffhunk://#diff-349d001931984d6c50353283db734dc95ef91e89f2df6bd9afe29a681d9d94a7R57-R129)

### Test Updates:
* [`tests/MyApp.Tests/Features/Movies/MovieServiceTests.cs`](diffhunk://#diff-707623209ab72f5028c8bf44bcf712e47c1fc6afa0f3e6a9a084038df2fadaf6L33-R33): Updated tests to include the `Rating` field in assertions.

Closes #29 