### PR TITLE
Add rating property to Movie class and update database schema

### DIFF
--- a/src/MyApp/Features/Shared/Movie.cs
+++ b/src/MyApp/Features/Shared/Movie.cs
@@ -7,4 +7,5 @@ public class Movie
     public int? DirectorId { get; set; }
     public Person? Director { get; set; }
     public int Year { get; set; }
+    public double Rating { get; set; }
 }

--- a/src/MyApp/Migrations/20240924111342_AddRatingToMovie.Designer.cs
+++ b/src/MyApp/Migrations/20240924111342_AddRatingToMovie.Designer.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using MyApp.Features.Shared;
 
@@ -10,9 +11,11 @@ using MyApp.Features.Shared;
 namespace MyApp.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240924111342_AddRatingToMovie")]
+    partial class AddRatingToMovie
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/MyApp/Migrations/20240924111342_AddRatingToMovie.cs
+++ b/src/MyApp/Migrations/20240924111342_AddRatingToMovie.cs
@@ -1,0 +1,99 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MyApp.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRatingToMovie : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Rating",
+                table: "Movies",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 1,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 2,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 3,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 4,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 5,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 6,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 7,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 8,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 9,
+                column: "Rating",
+                value: 0.0);
+
+            migrationBuilder.UpdateData(
+                table: "Movies",
+                keyColumn: "Id",
+                keyValue: 10,
+                column: "Rating",
+                value: 0.0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Rating",
+                table: "Movies");
+        }
+    }
+}

--- a/src/MyApp/appsettings.Development.json
+++ b/src/MyApp/appsettings.Development.json
@@ -6,6 +6,6 @@
     }
   },
   "ConnectionStrings": {
-    "AppDbContext": "Server=(localdb)\\MSSQLLocalDB;Database=Movies2;Trusted_Connection=True;MultipleActiveResultSets=true"
+    "AppDbContext": "Server=(localdb)\\MSSQLLocalDB;Database=Movies42;Trusted_Connection=True;MultipleActiveResultSets=true"
   }
 }


### PR DESCRIPTION
This pull request introduces a new `Rating` property to the `Movie` class and updates the database schema to support this change. The most important changes include adding the `Rating` property, creating a migration to update the database, and modifying the database context and snapshot files.

### Changes to Movie class:
* [`src/MyApp/Features/Shared/Movie.cs`](diffhunk://#diff-6d0fb19b792c8b0acf7afb8175d9586063ceeb678c1f3b0d8e4fec77b9491233R10): Added a new `Rating` property to the `Movie` class.

### Database schema updates:
* [`src/MyApp/Migrations/20240924111342_AddRatingToMovie.Designer.cs`](diffhunk://#diff-0606b0538be2a39de28efc4709343435065b473c577bcbd39c84f0c4015618c6R1-R214): Added a migration designer file to include the `Rating` property in the `Movies` table and seeded initial data.
* [`src/MyApp/Migrations/20240924111342_AddRatingToMovie.cs`](diffhunk://#diff-19847874d0a538e8d93e0cd1626dd18b2fa1e5411febcf39bbd2e4fe72449c5bR1-R99): Created a migration file to add the `Rating` column to the `Movies` table and update existing records with a default rating of 0.0.
* [`src/MyApp/Migrations/AppDbContextModelSnapshot.cs`](diffhunk://#diff-349d001931984d6c50353283db734dc95ef91e89f2df6bd9afe29a681d9d94a7R35-R37): Updated the model snapshot to reflect the new `Rating` property and seeded data. [[1]](diffhunk://#diff-349d001931984d6c50353283db734dc95ef91e89f2df6bd9afe29a681d9d94a7R35-R37) [[2]](diffhunk://#diff-349d001931984d6c50353283db734dc95ef91e89f2df6bd9afe29a681d9d94a7R57-R129)

### Configuration update:
* [`src/MyApp/appsettings.Development.json`](diffhunk://#diff-9b35418550d4969d94566928e9e2b918ae6f1fb78df79fd1f3ce7f26fad33f65L9-R9): Updated the connection string to point to a new database `Movies42`.

References #29 