### PR TITLE
Update Azure/sql-action to v2.3

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -112,7 +112,7 @@ jobs:
             echo "CONNECTION_STRING=${CONNECTION_STRING/Authentication=ActiveDirectoryManagedIdentity/Authentication=\"Active Directory Default\"}" >> "$GITHUB_ENV"
 
       - name: Apply EF migration script
-        uses: Azure/sql-action@v2
+        uses: Azure/sql-action@v2.3
         with:
           connection-string: ${{ env.CONNECTION_STRING }}
           path: migrate.sql
@@ -160,7 +160,7 @@ jobs:
             echo "CONNECTION_STRING=${CONNECTION_STRING/Authentication=ActiveDirectoryManagedIdentity/Authentication=\"Active Directory Default\"}" >> "$GITHUB_ENV"
 
       - name: Apply EF migration script
-        uses: Azure/sql-action@v2
+        uses: Azure/sql-action@v2.3
         with:
           connection-string: ${{ env.CONNECTION_STRING }}
           path: migrate.sql


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to use a more recent version of the Azure SQL action.

Updates to GitHub Actions workflow:

* [`.github/workflows/application.yml`](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L115-R115): Updated the `Azure/sql-action` from version `v2` to `v2.3` in the steps that apply the EF migration script. [[1]](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L115-R115) [[2]](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L163-R163)