### PR TITLE
Update Azure CLI version in workflow and infrastructure files

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -106,7 +106,6 @@ jobs:
       - name: Get Connection String
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             CONNECTION_STRING=$(az webapp config appsettings list --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --slot ${{ vars.DEPLOYMENT_SLOT }} --query "[?name=='AZURE_SQL_CONNECTIONSTRING'].value" --output tsv)
             echo "CONNECTION_STRING=${CONNECTION_STRING/Authentication=ActiveDirectoryManagedIdentity/Authentication=\"Active Directory Default\"}" >> "$GITHUB_ENV"
@@ -120,7 +119,6 @@ jobs:
       - name: Deploy Web App
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az webapp deploy --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --slot ${{ vars.DEPLOYMENT_SLOT }} --src-path app.zip --clean
 
@@ -154,7 +152,6 @@ jobs:
       - name: Get Connection String
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             CONNECTION_STRING=$(az webapp config appsettings list --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --query "[?name=='AZURE_SQL_CONNECTIONSTRING'].value" --output tsv)
             echo "CONNECTION_STRING=${CONNECTION_STRING/Authentication=ActiveDirectoryManagedIdentity/Authentication=\"Active Directory Default\"}" >> "$GITHUB_ENV"
@@ -168,6 +165,5 @@ jobs:
       - name: Swap Staging With Production
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az webapp deployment slot swap --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --slot ${{ vars.DEPLOYMENT_SLOT }}

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Build Bicep Files
         uses: azure/cli@v2.1.0
         with:
+          azcliversion: 2.63.0
           inlineScript: |
             az bicep build --file infrastructure/main.bicep --outfile infrastructure/main.json
             az bicep build-params --file infrastructure/main.bicepparam --outfile infrastructure/main.parameters.json

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Lint Bicep Files
         uses: azure/cli@v2.1.0
         with:
+          azcliversion: 2.63.0
           inlineScript: |
             az bicep lint --file infrastructure/main.bicep
             az bicep lint --file infrastructure/main.bicepparam

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Lint Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az bicep lint --file infrastructure/main.bicep
             az bicep lint --file infrastructure/main.bicepparam
@@ -39,7 +38,6 @@ jobs:
       - name: Build Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az bicep build --file infrastructure/main.bicep --outfile infrastructure/main.json
             az bicep build-params --file infrastructure/main.bicepparam --outfile infrastructure/main.parameters.json
@@ -77,7 +75,6 @@ jobs:
       - name: Create Resource Group
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az group create --name ${{ vars.RESOURCE_GROUP }} --location ${{ vars.LOCATION }}
 
@@ -127,7 +124,6 @@ jobs:
       - name: Create Resource Group
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
           inlineScript: |
             az group create --name ${{ vars.RESOURCE_GROUP }} --location ${{ vars.LOCATION }}
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
     "Antiforgery",
     "appsettings",
     "ASPNETCORE",
-    "azcliversion",
     "bicepparam",
     "CONNECTIONSTRING",
     "connectionstrings",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "Antiforgery",
     "appsettings",
     "ASPNETCORE",
+    "azcliversion",
     "bicepparam",
     "CONNECTIONSTRING",
     "connectionstrings",


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows for both application deployment and infrastructure setup. The main change involves removing the `azcliversion` parameter from various steps that use the Azure CLI.

Changes in `.github/workflows/application.yml`:

* Removed the `azcliversion` parameter from the "Get Connection String" step. (`[.github/workflows/application.ymlL109](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L109)`)
* Removed the `azcliversion` parameter from the "Deploy Web App" step. (`[.github/workflows/application.ymlL123](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L123)`)
* Removed the `azcliversion` parameter from another "Get Connection String" step. (`[.github/workflows/application.ymlL157](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L157)`)
* Removed the `azcliversion` parameter from the "Swap Staging With Production" step. (`[.github/workflows/application.ymlL171](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L171)`)

Changes in `.github/workflows/infrastructure.yml`:

* Removed the `azcliversion` parameter from the "Create Resource Group" step. (`[.github/workflows/infrastructure.ymlL80](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L80)`)
* Removed the `azcliversion` parameter from another "Create Resource Group" step. (`[.github/workflows/infrastructure.ymlL130](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L130)`)