### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -143,11 +143,11 @@ jobs:
         with:
           inlineScript: |
             WEBAPP_IDENTITY=$(az webapp show --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --slot ${{ vars.DEPLOYMENT_SLOT }} --query identity.principalId --output tsv)
-            az role assignment create --role "AcrPull" --assignee $WEBAPP_IDENTITY --scope ${{ vars.CONTAINER_REGISTRY }} --assignee-principal-type ServicePrincipal
+            az role assignment create --role "AcrPull" --assignee-object-id $WEBAPP_IDENTITY --scope ${{ vars.CONTAINER_REGISTRY }} --assignee-principal-type ServicePrincipal
 
       - name: Assign AcrPull to Web App
         uses: azure/cli@v2.1.0
         with:
           inlineScript: |
             WEBAPP_IDENTITY=$(az webapp show --resource-group ${{ vars.RESOURCE_GROUP }} --name ${{ vars.WEBAPP }} --query identity.principalId --output tsv)
-            az role assignment create --role "AcrPull" --assignee $WEBAPP_IDENTITY --scope ${{ vars.CONTAINER_REGISTRY }} --assignee-principal-type ServicePrincipal
+            az role assignment create --role "AcrPull" --assignee-object-id $WEBAPP_IDENTITY --scope ${{ vars.CONTAINER_REGISTRY }} --assignee-principal-type ServicePrincipal

--- a/scripts/New-AzureWebSitesSqlConnection.ps1
+++ b/scripts/New-AzureWebSitesSqlConnection.ps1
@@ -26,8 +26,8 @@ param (
 az extension add --upgrade --name serviceconnector-passwordless
 
 if ($DeploymentSlotName) {
-    az webapp connection create sql --resource-group $ResourceGroupName --name $WebAppName --slot $DeploymentSlotName --target-resource-group $SqlServerResourceGroupName --server $SqlServerName --database $DatabaseName --system-identity --client-type dotnet --connection $DatabaseName
+    az webapp connection create sql --resource-group $ResourceGroupName --name $WebAppName --slot $DeploymentSlotName --target-resource-group $SqlServerResourceGroupName --server $SqlServerName --database $DatabaseName --system-identity --client-type dotnet --connection $DatabaseName --new
 }
 else {
-    az webapp connection create sql --resource-group $ResourceGroupName --name $WebAppName --target-resource-group $SqlServerResourceGroupName --server $SqlServerName --database $DatabaseName --system-identity --client-type dotnet --connection $DatabaseName
+    az webapp connection create sql --resource-group $ResourceGroupName --name $WebAppName --target-resource-group $SqlServerResourceGroupName --server $SqlServerName --database $DatabaseName --system-identity --client-type dotnet --connection $DatabaseName --new
 }


### PR DESCRIPTION
This pull request includes changes to the Azure deployment scripts and workflows to update command parameters for role assignments and SQL connections. The most important changes involve modifying the `az role assignment create` and `az webapp connection create sql` commands to ensure proper parameter usage.

### Azure Deployment Script Updates:

* [`.github/workflows/infrastructure.yml`](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L146-R153): Updated the `az role assignment create` command to use the `--assignee-object-id` parameter instead of `--assignee` for assigning the `AcrPull` role to the Web App identity.

* [`scripts/New-AzureWebSitesSqlConnection.ps1`](diffhunk://#diff-f4776d9da31ab4f96a6acbcb18ebfaeb2cf24383ee43b475e6ccaf1a13a2c5caL29-R32): Added the `--new` parameter to the `az webapp connection create sql` command to create a new connection for both deployment slot and non-deployment slot scenarios.