### PR TITLE
Upgrade packages

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.1
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v4.0.1
@@ -87,7 +87,7 @@ jobs:
         run: dotnet ef migrations script --idempotent --project src/MovieApi/ --startup-project src/MovieApi/ --no-build --output migrate.sql
 
       - name: Upload EF Migration Script
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: migrate.sql
           path: migrate.sql

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Lint Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          # azcliversion: 2.63.0
+          azcliversion: 2.63.0
           inlineScript: |
             az bicep lint --file infrastructure/main.bicep
             az bicep lint --file infrastructure/main.bicepparam
@@ -39,7 +39,7 @@ jobs:
       - name: Build Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          # azcliversion: 2.63.0
+          azcliversion: 2.63.0
           inlineScript: |
             az bicep build --file infrastructure/main.bicep --outfile infrastructure/main.json
             az bicep build-params --file infrastructure/main.bicepparam --outfile infrastructure/main.parameters.json

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -26,12 +26,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.1
 
       - name: Lint Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
+          # azcliversion: 2.63.0
           inlineScript: |
             az bicep lint --file infrastructure/main.bicep
             az bicep lint --file infrastructure/main.bicepparam
@@ -39,13 +39,13 @@ jobs:
       - name: Build Bicep Files
         uses: azure/cli@v2.1.0
         with:
-          azcliversion: 2.63.0
+          # azcliversion: 2.63.0
           inlineScript: |
             az bicep build --file infrastructure/main.bicep --outfile infrastructure/main.json
             az bicep build-params --file infrastructure/main.bicepparam --outfile infrastructure/main.parameters.json
 
       - name: Upload Bicep Files
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4.4.1
         with:
           name: infrastructure
           path: infrastructure/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4.2.0
+        uses: actions/checkout@v4.2.1
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits


### PR DESCRIPTION
This pull request includes minor updates to the GitHub Actions workflows to use the latest versions of certain actions. The changes ensure that the workflows are using the most up-to-date versions of the `checkout` and `upload-artifact` actions.

Updates to GitHub Actions workflows:

* [`.github/workflows/application.yml`](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L40-R40): Updated `actions/checkout` to version `v4.2.1` and `actions/upload-artifact` to version `v4.4.1`. [[1]](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L40-R40) [[2]](diffhunk://#diff-dc5f32521b4ae99ff8632eb151f06cb36a62fe139292cbbf3f2a4afc79647581L90-R90)
* [`.github/workflows/infrastructure.yml`](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L29-R29): Updated `actions/checkout` to version `v4.2.1` and `actions/upload-artifact` to version `v4.4.1`. [[1]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L29-R29) [[2]](diffhunk://#diff-87064d625758a43d5c34f6188c42c132d0df6dd171c0f93185cef24ba9c21f40L48-R48)
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L26-R26): Updated `actions/checkout` to version `v4.2.1`.