### PR TITLE
Use latest SQL Server

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     network_mode: service:db
 
   db:
-    image: mcr.microsoft.com/mssql/server:2022-latest
+    image: mcr.microsoft.com/mssql/server:latest
     restart: unless-stopped
     environment:
       MSSQL_SA_PASSWORD: <YourStrong@Passw0rd>

--- a/tests/MovieApi.Tests/Models/MovieDbContextTests.cs
+++ b/tests/MovieApi.Tests/Models/MovieDbContextTests.cs
@@ -2,7 +2,7 @@ namespace MovieApi.Tests.Models;
 
 public sealed class MovieDbContextTests : IAsyncLifetime
 {
-    private readonly MsSqlContainer _database = new MsSqlBuilder().Build();
+    private readonly MsSqlContainer _database = new MsSqlBuilder().WithImage("mcr.microsoft.com/mssql/server:latest").Build();
 
     [Fact]
     public async Task After_migration_database_contains_people()


### PR DESCRIPTION
This pull request includes updates to the database image used in the development environment and test suite to ensure consistency and use the latest version.

Database image updates:

* [`.devcontainer/docker-compose.yml`](diffhunk://#diff-67a4805fdcc6145d7b3ada2a6099a9b2e91c9d0fd108c22f95d2f01d219793d1L20-R20): Changed the database image from `mcr.microsoft.com/mssql/server:2022-latest` to `mcr.microsoft.com/mssql/server:latest` to always use the latest version.
* [`tests/MovieApi.Tests/Models/MovieDbContextTests.cs`](diffhunk://#diff-6a2d712ff601161581eab0ace1d8ecc3fdd2e5eae0c1d3bfe73bc54aeceac738L5-R5): Updated the `MsSqlContainer` to use the latest image version by specifying `mcr.microsoft.com/mssql/server:latest` in the `WithImage` method.

Closes #55 