### PR TITLE
Update Azure Container Registry image tagging and deployment logic

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -70,12 +70,15 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Push Image to Azure Container Registry
+        if: github.ref == 'refs/heads/main' || github.event_name == 'pull_request'
         run: |
           az acr login --name ${{ vars.CONTAINER_REGISTRY }}
           IMAGE="${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo"
-          docker tag "ondfisk-githubdemo:${{ github.sha }}" "$IMAGE:1.0"
           docker tag "ondfisk-githubdemo:${{ github.sha }}" "$IMAGE:${{ github.sha }}"
+          docker tag "ondfisk-githubdemo:${{ github.sha }}" "$IMAGE:${{ env.IMAGE_TAG }}"
           docker push $IMAGE --all-tags
+        env:
+          IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'test' }}
 
       - name: Install EF Tool
         run: |
@@ -136,7 +139,9 @@ jobs:
         with:
           app-name: ${{ vars.WEBAPP }}
           slot-name: ${{ vars.DEPLOYMENT_SLOT }}
-          images: ${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo:${{ github.sha }}
+          images: ${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo:${{ env.IMAGE_TAG }}
+        env:
+          IMAGE_TAG: ${{ github.ref == 'refs/heads/main' && 'latest' || 'test' }}
 
   production:
     name: Deploy to Production
@@ -147,7 +152,6 @@ jobs:
 
     env:
       CONNECTION_STRING:
-      VERSION: "1.0"
 
     permissions:
       id-token: write
@@ -178,15 +182,6 @@ jobs:
         with:
           connection-string: ${{ env.CONNECTION_STRING }}
           path: migrate.sql
-
-      - name: Tag Image with latest
-        run: |
-          az acr login --name ${{ vars.CONTAINER_REGISTRY }}
-          IMAGE="${{ vars.CONTAINER_REGISTRY }}.azurecr.io/ondfisk-githubdemo"
-          docker pull "$IMAGE:${{ github.sha }}"
-          docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:latest"
-          docker tag "$IMAGE:${{ github.sha }}" "$IMAGE:${{ env.VERSION }}"
-          docker push $IMAGE --all-tags
 
       - name: Swap Staging With Production
         uses: azure/cli@v2.1.0


### PR DESCRIPTION
This pull request includes several updates to the GitHub Actions workflow configuration in the `.github/workflows/application.yml` file. The changes primarily focus on improving the tagging and pushing of Docker images to the Azure Container Registry, as well as updating the deployment process.

Improvements to image tagging and pushing:

* Added a condition to the "Push Image to Azure Container Registry" step to run only on the main branch or pull requests, and introduced an `IMAGE_TAG` environment variable to differentiate between 'latest' and 'test' tags.
* Updated the image tag used in the deployment step to use the `IMAGE_TAG` environment variable instead of the commit SHA.

Simplification of workflow steps:

* Removed the redundant "Tag Image with latest" step, as the image tagging is now handled in the earlier steps.

Closes #71 

Other minor changes:

* Removed the unused `VERSION` environment variable from the environment settings.