### PR TITLE
Update devcontainer configuration and bump package versions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
       "installBicep": true,
       "extensions": "serviceconnector-passwordless"
     },
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers/features/dotnet:2": {
       "version": "lts"
     },
@@ -32,7 +32,7 @@
         "ms-azuretools.vscode-docker",
         "ms-dotnettools.csharp",
         "ms-dotnettools.vscodeintellicode-csharp",
-        "ms-vscode.azure-account",
+        "ms-azuretools.vscode-azureresourcegroups",
         "ms-vscode.powershell",
         "redhat.vscode-yaml",
         "streetsidesoftware.code-spell-checker"

--- a/src/MovieApi/MovieApi.csproj
+++ b/src/MovieApi/MovieApi.csproj
@@ -13,11 +13,11 @@
   <ItemGroup>
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.2" />
-    <PackageReference Include="Microsoft.EntityframeworkCore.Design" Version="9.0.1">
+    <PackageReference Include="Microsoft.EntityframeworkCore.Design" Version="9.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityframeworkCore.SqlServer" Version="9.0.1" />
+    <PackageReference Include="Microsoft.EntityframeworkCore.SqlServer" Version="9.0.2" />
   </ItemGroup>
 
 </Project>

--- a/tests/MovieApi.Tests/MovieApi.Tests.csproj
+++ b/tests/MovieApi.Tests/MovieApi.Tests.csproj
@@ -9,11 +9,14 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
-    <PackageReference Include="Microsoft.EntityframeworkCore.Sqlite" Version="9.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.EntityframeworkCore.Sqlite" Version="9.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="Testcontainers.MsSql" Version="4.2.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="XunitXml.TestLogger" Version="6.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request includes updates to the development container configuration and package dependencies in the project. The most important changes include switching to a different Docker feature, updating Visual Studio Code extensions, and upgrading several package dependencies.

Development container configuration updates:

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L11-R11): Changed the Docker feature from `docker-in-docker` to `docker-outside-of-docker`.
* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L35-R35): Replaced the `ms-vscode.azure-account` extension with `ms-azuretools.vscode-azureresourcegroups`.

Package dependency upgrades:

* [`src/MovieApi/MovieApi.csproj`](diffhunk://#diff-8efe867133c371fe63dbb1c4a65f566f5d0fc0510982a0fe137415aada7331c7L16-R20): Upgraded `Microsoft.EntityframeworkCore.Design` and `Microsoft.EntityframeworkCore.SqlServer` to version `9.0.2`.
* [`tests/MovieApi.Tests/MovieApi.Tests.csproj`](diffhunk://#diff-ac7ca47175cbdb1d51ec6567747d40de871dcfd65792f37989369e4b81b4bf96L12-R19): Upgraded `Microsoft.EntityframeworkCore.Sqlite` to version `9.0.2`, `Microsoft.NET.Test.Sdk` to version `17.13.0`, and `xunit.runner.visualstudio` to version `3.0.2`.