### PR TITLE
Refactor concurrency group naming and update PostgreSQL access instructions

### DIFF
--- a/.github/workflows/application.yml
+++ b/.github/workflows/application.yml
@@ -19,8 +19,7 @@ name: Application
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: application-and-infrastructure-${{ github.ref }}
 
 permissions: {}
 

--- a/.github/workflows/infrastructure.yml
+++ b/.github/workflows/infrastructure.yml
@@ -17,8 +17,7 @@ name: Infrastructure
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: application-and-infrastructure-${{ github.ref }}
 
 permissions: {}
 

--- a/README.md
+++ b/README.md
@@ -121,11 +121,18 @@ This repository demonstrates a number of capabilities in GitHub and Microsoft Az
 
 1. Push the changes to trigger the _infrastructure_ workflow.
 
+1. Grant _SPN_ access to PostgreSQL server:
+
+   ```bash
+   DATABASE_SERVER=$(az postgres flexible-server list --resource-group $RESOURCE_GROUP --query [].name --output tsv)
+
+   az postgres flexible-server microsoft-entra-admin create --display-name "$APP_REGISTRATION_DISPLAY_NAME" --object-id $OBJECT_ID --resource-group $RESOURCE_GROUP --server-name $DATABASE_SERVER --type ServicePrincipal
+   ```
+
 1. Grant web app permission to database:
 
    ```bash
    WEB_APP=$(az webapp list --resource-group $RESOURCE_GROUP --query [].name --output tsv)
-   DATABASE_SERVER=$(az postgres flexible-server list --resource-group $RESOURCE_GROUP --query [].name --output tsv)
    SLOT="staging"
    DATABASE="Movies"
    STAGING_DATABASE="MoviesStaging"

--- a/infrastructure/main.bicep
+++ b/infrastructure/main.bicep
@@ -1,6 +1,5 @@
 param location string = resourceGroup().location
 param appServicePlanSku string = 'P0v3'
-
 param logAnalyticsWorkspaceId string
 
 var deploymentSlotName = 'staging'
@@ -134,16 +133,6 @@ resource postgresqlServer 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01'
       passwordAuth: 'Disabled'
       tenantId: tenant().tenantId
     }
-  }
-}
-
-resource postgresqlAdministrators 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
-  parent: postgresqlServer
-  name: deployer().objectId
-  properties: {
-    tenantId: tenant().tenantId
-    principalName: deployer().userPrincipalName
-    principalType: 'Group'
   }
 }
 


### PR DESCRIPTION
Update concurrency group naming in workflows for clarity and enhance the README with instructions for granting SPN access to the PostgreSQL server.