### PR TITLE
Update package references in MovieApi and MovieApi.Tests projects to …

### DIFF
--- a/src/MovieApi/MovieApi.csproj
+++ b/src/MovieApi/MovieApi.csproj
@@ -11,10 +11,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.14.1" />
+    <PackageReference Include="Azure.Identity" Version="1.15.0" />
     <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.6" />
-    <PackageReference Include="Microsoft.EntityframeworkCore.Design" Version="9.0.6">
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.8" />
+    <PackageReference Include="Microsoft.EntityframeworkCore.Design" Version="9.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/MovieApi.Tests/MovieApi.Tests.csproj
+++ b/tests/MovieApi.Tests/MovieApi.Tests.csproj
@@ -19,14 +19,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityframeworkCore.Sqlite" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityframeworkCore.Sqlite" Version="9.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.6.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request updates several NuGet package dependencies to their latest patch versions in both the main API project and the test project. These updates primarily focus on keeping the project secure and compatible with the latest features and bug fixes.

Dependency updates:

* Upgraded `Azure.Identity` from version 1.14.1 to 1.15.0 in `MovieApi.csproj` to ensure compatibility with the latest Azure authentication features and security patches.
* Updated `Microsoft.AspNetCore.OpenApi` and `Microsoft.EntityframeworkCore.Design` to version 9.0.8 in `MovieApi.csproj` for improved ASP.NET Core OpenAPI support and Entity Framework Core tooling.
* Upgraded `Microsoft.EntityframeworkCore.Sqlite` from 9.0.6 to 9.0.8 in `MovieApi.Tests.csproj` for better SQLite support in tests.
* Updated test dependencies: `xunit.runner.visualstudio` to 3.1.4 and `xunit.v3` to 3.0.1 in `MovieApi.Tests.csproj`, ensuring the latest test runner features and bug fixes.…latest versions